### PR TITLE
Added RavenUserAuthRepository Indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ App_Data/
 *.resharper.user
 *.suo
 *.user
+
+# NCrunch
+
+*.ncrunch*
+
+.*crunch*.local.xml

--- a/src/ServiceStack.Authentication.Raven/ServiceStack.Authentication.Raven.csproj
+++ b/src/ServiceStack.Authentication.Raven/ServiceStack.Authentication.Raven.csproj
@@ -55,6 +55,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ServiceStack_UserAuth_ByOAuthProvider.cs" />
+    <Compile Include="ServiceStack_UserAuth_ByUserNameOrEmail.cs" />
     <Compile Include="RavenUserAuthRepository.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/ServiceStack.Authentication.Raven/ServiceStack_UserAuth_ByOAuthProvider.cs
+++ b/src/ServiceStack.Authentication.Raven/ServiceStack_UserAuth_ByOAuthProvider.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using Raven.Client.Indexes;
+using ServiceStack.ServiceInterface.Auth;
+
+namespace ServiceStack.Authentication.Raven
+{
+    public class ServiceStack_UserAuth_ByOAuthProvider : AbstractIndexCreationTask<UserOAuthProvider, ServiceStack_UserAuth_ByOAuthProvider.Result>
+    {
+        public class Result
+        {
+            public string Provider { get; set; }
+            public string UserId { get; set; }
+            public int UserAuthId { get; set; }
+            public DateTime ModifiedDate { get; set; }
+        }
+
+        public ServiceStack_UserAuth_ByOAuthProvider()
+        {
+            Map = oauthProviders => from oauthProvider in oauthProviders
+                                    select new Result
+                                    {
+                                        Provider = oauthProvider.Provider,
+                                        UserId = oauthProvider.UserId,
+                                        ModifiedDate = oauthProvider.ModifiedDate,
+                                        UserAuthId = oauthProvider.UserAuthId
+                                    };
+        }
+    }
+}

--- a/src/ServiceStack.Authentication.Raven/ServiceStack_UserAuth_ByUserNameOrEmail.cs
+++ b/src/ServiceStack.Authentication.Raven/ServiceStack_UserAuth_ByUserNameOrEmail.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using Raven.Abstractions.Indexing;
+using Raven.Client.Indexes;
+using ServiceStack.ServiceInterface.Auth;
+
+namespace ServiceStack.Authentication.Raven
+{
+    public class ServiceStack_UserAuth_ByUserNameOrEmail : AbstractIndexCreationTask<UserAuth, ServiceStack_UserAuth_ByUserNameOrEmail.Result>
+    {
+        public class Result
+        {
+            public string UserName { get; set; }
+            public string Email { get; set; }
+            public string[] Search { get; set; }
+        }
+
+        public ServiceStack_UserAuth_ByUserNameOrEmail()
+        {
+            Map = users => from user in users
+                           select new Result
+                           {
+                               UserName = user.UserName,
+                               Email = user.Email,
+                               Search = new[] { user.UserName, user.Email }
+                           };
+
+            Index(x => x.Search, FieldIndexing.Analyzed);
+        }
+    }
+}


### PR DESCRIPTION
The original implementation was great, but was depending on temporary indexes to query for users and emails. The issue with this is temporary indexes is that they are cleared after a period of inactivity and you will get no results back as it builds that index for the first time. 

The changes here insure that you are hitting indexes that are permanent and that will be as current as any other RavenDB index.

```
ServiceStack/UserAuth/ByUsernameOrEmail
ServiceStack/UserAuth/ByOAuthProvider
```

You can either call the static method I provided and it will execute the indexes on your DocumentStore, or the first time a RavenUserAuthRepository is created the indexes will be PUT into the database. RavenDB is smart about index changes so even if it is called a few times it is not a huge performance hit (no need to do any locking).

I've tested this in another project and it seems to be working nicely, but please test this out yourself.
