### PR TITLE
Fix for GetUserAuth from RavenDB returning null

### DIFF
--- a/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
+++ b/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
@@ -202,10 +202,10 @@ namespace ServiceStack.Authentication.RavenDb
 		{
 			using (var session = _documentStore.OpenSession())
 			{
-                int authId;
-                if (int.TryParse(userAuthId, out authId))
-                    return session.Load<UserAuth>(authId); 
-                return session.Load<UserAuth>(userAuthId);
+                int intAuthId;
+                return int.TryParse(userAuthId, out intAuthId) 
+                    ? session.Load<UserAuth>(intAuthId) 
+                    : session.Load<UserAuth>(userAuthId);
 			}
 		}
 

--- a/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
+++ b/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
@@ -202,7 +202,10 @@ namespace ServiceStack.Authentication.RavenDb
 		{
 			using (var session = _documentStore.OpenSession())
 			{
-				return session.Load<UserAuth>(userAuthId);
+                int authId;
+                if (int.TryParse(userAuthId, out authId))
+                    return session.Load<UserAuth>(authId); 
+                return session.Load<UserAuth>(userAuthId);
 			}
 		}
 


### PR DESCRIPTION
"GetUserAuth(string userAuthId)" returns null, unless you passed in the full Raven document Id (e.g. UserAuths/1)

Converted the UserAuthId to an Int so Raven can load the document by Id.
