### PR TITLE
Registration with autologin fails when using the RavenUserAuthRepository

### DIFF
--- a/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
+++ b/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
@@ -137,6 +137,7 @@ namespace ServiceStack.Authentication.RavenDb
             using (var session = _documentStore.OpenSession())
             {
                 var userAuth = session.Query<ServiceStack_UserAuth_ByUserNameOrEmail.Result, ServiceStack_UserAuth_ByUserNameOrEmail>()
+                       .Customize(x => x.WaitForNonStaleResultsAsOfNow())
                        .Search(x => x.Search, userNameOrEmail)
                        .OfType<UserAuth>()
                        .FirstOrDefault();
@@ -247,6 +248,7 @@ namespace ServiceStack.Authentication.RavenDb
 			{
 				var id = int.Parse(userAuthId);
 				return session.Query<ServiceStack_UserAuth_ByOAuthProvider.Result, ServiceStack_UserAuth_ByOAuthProvider>()
+                    .Customize(x => x.WaitForNonStaleResultsAsOfNow())
                     .Where(q => q.UserAuthId == id)
                     .OrderBy(x => x.ModifiedDate)
                     .OfType<UserOAuthProvider>()
@@ -274,6 +276,7 @@ namespace ServiceStack.Authentication.RavenDb
 			{
 			    var oAuthProvider = session
 			        .Query<ServiceStack_UserAuth_ByOAuthProvider.Result, ServiceStack_UserAuth_ByOAuthProvider>()
+                    .Customize(x => x.WaitForNonStaleResultsAsOfNow())
 			        .Where(q => q.Provider == tokens.Provider && q.UserId == tokens.UserId)
                     .OfType<UserOAuthProvider>()
 			        .FirstOrDefault();
@@ -295,6 +298,7 @@ namespace ServiceStack.Authentication.RavenDb
 			{
                 var oAuthProvider = session
                     .Query<ServiceStack_UserAuth_ByOAuthProvider.Result, ServiceStack_UserAuth_ByOAuthProvider>()
+                    .Customize(x => x.WaitForNonStaleResultsAsOfNow())
                     .Where(q => q.Provider == tokens.Provider && q.UserId == tokens.UserId)
                     .OfType<UserOAuthProvider>()
                     .FirstOrDefault();


### PR DESCRIPTION
RavenDB uses background indexing and allows the use of stale indexes by default, which is great for a lot of things, but security generally isn't one of them.

Specifically, if you try to register with `autoLogin` set (i.e. using the `RegistrationFeature`) while using the RavenDB repository, you end up with an "Invalid UserName or Password" error at the end of it. That is because the service immediately attempts a login after creating the user auth, and when it goes to retrieve the auth document afterward (via `GetUserAuthByUserName`), it's not in the index yet.

Adding `WaitForNonStaleResultsAsOfNow` ensures that any recent user creations/saves are reflected in the query. I've added it to the OAuth queries too, since they are susceptible to similar issues.
