### PR TITLE
Added MemcachedClientCache.ctor() that takes an IMemcachedClientConfiguration instance

### DIFF
--- a/src/ServiceStack.CacheAccess.Memcached/MemcachedClientCache.cs
+++ b/src/ServiceStack.CacheAccess.Memcached/MemcachedClientCache.cs
@@ -67,10 +67,10 @@ namespace ServiceStack.CacheAccess.Memcached
 		}
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MemcachedClientCache"/> class based on an existing <see cref="MemcachedClientConfiguration"/>.
+        /// Initializes a new instance of the <see cref="MemcachedClientCache"/> class based on an existing <see cref="IMemcachedClientConfiguration"/>.
         /// </summary>
-        /// <param name="memcachedClientConfiguration">The <see cref="MemcachedClientConfiguration"/>.</param>
-        public MemcachedClientCache(MemcachedClientConfiguration memcachedClientConfiguration)
+        /// <param name="memcachedClientConfiguration">The <see cref="IMemcachedClientConfiguration"/>.</param>
+        public MemcachedClientCache(IMemcachedClientConfiguration memcachedClientConfiguration)
         {
             LoadClient(memcachedClientConfiguration);
         }
@@ -80,7 +80,7 @@ namespace ServiceStack.CacheAccess.Memcached
         /// </summary>
         /// <param name="ipEndpoints">The ip endpoints.</param>
         /// <returns></returns>
-	    private MemcachedClientConfiguration PrepareMemcachedClientConfiguration(IEnumerable<IPEndPoint> ipEndpoints)
+        private IMemcachedClientConfiguration PrepareMemcachedClientConfiguration(IEnumerable<IPEndPoint> ipEndpoints)
 	    {
             var config = new MemcachedClientConfiguration();
             foreach (var ipEndpoint in ipEndpoints)
@@ -96,7 +96,7 @@ namespace ServiceStack.CacheAccess.Memcached
             return config;
 	    }
 
-		private void LoadClient(MemcachedClientConfiguration config)
+		private void LoadClient(IMemcachedClientConfiguration config)
 		{
             Enyim.Caching.LogManager.AssignFactory(new EnyimLogFactoryWrapper());
             


### PR DESCRIPTION
Demis,

as mentioned on Google Groups here's the pull request for an added .ctor() that allows devs working with the MemcachedClientCache to provide a custom / predefined MemcachedClientConfiguration instance along with it.

I tried to adhere to the rest of the coding style inside the class & basically just did the following:
1. Added the new .ctor() (line #73)
2. Added a new private method that prepares the default configuration for the other two already existing ctor's (taking hostnames/ipEndPoints) (line #83)
3. ... and only perform the 'common' part (_client assignment & LogManager.AssignFactory() call) in LoadClient() (line #99)

Hope that's fine, if not, let me know what to change there.

Thanks!
-Jörg
