### PR TITLE
Made password optional when calling UpdateUserAuth.

### DIFF
--- a/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
+++ b/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
@@ -39,8 +39,14 @@ namespace ServiceStack.Authentication.RavenDb
 
 		private void ValidateNewUser(UserAuth newUser, string password)
 		{
-			newUser.ThrowIfNull("newUser");
 			password.ThrowIfNullOrEmpty("password");
+
+			ValidateNewUserWithoutPassword(newUser);
+		}
+
+		private void ValidateNewUserWithoutPassword(UserAuth newUser)
+		{
+			newUser.ThrowIfNull("newUser");
 
 			if (newUser.UserName.IsNullOrEmpty() && newUser.Email.IsNullOrEmpty())
 				throw new ArgumentNullException("UserName or Email is required");
@@ -96,9 +102,9 @@ namespace ServiceStack.Authentication.RavenDb
 			}
 		}
 
-		public UserAuth UpdateUserAuth(UserAuth existingUser, UserAuth newUser, string password)
+		public UserAuth UpdateUserAuth(UserAuth existingUser, UserAuth newUser, string password = null)
 		{
-			ValidateNewUser(newUser, password);
+			ValidateNewUserWithoutPassword(newUser);
 
 			AssertNoExistingUser(newUser, existingUser);
 


### PR DESCRIPTION
Updating a UserAuth without having the raw password is not possible.  

Made the password parameter optional in the `UpdateUserAuth` method.  

I also believe that this was your original intention that this should be possible seeing the null checks happening on the password variable within `UpdateUserAuth`. These are useless in the current implementation because an exception will be thrown on the assert in `ValidateNewUser` and the code will never reach the null checks anyway.
