### PR TITLE
UserAuth should be retrieved using integer ID in RavenUserAuthRepository.

### DIFF
--- a/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
+++ b/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
@@ -207,9 +207,11 @@ namespace ServiceStack.Authentication.RavenDb
 
 		public UserAuth GetUserAuth(string userAuthId)
 		{
+			var id = int.Parse(userAuthId);
+
 			using (var session = _documentStore.OpenSession())
 			{
-				return session.Load<UserAuth>(userAuthId);
+				return session.Load<UserAuth>(id);
 			}
 		}
 


### PR DESCRIPTION
The GetUserAuth method needs to convert the userAuthId to an int before loading the UserAuth from Raven. If a string is used, Raven can load the wrong document causing a cast exception when it tries to convert it to a UserAuth.
