### PR TITLE
Removed new IDocumentSession instantiation from GetUserAuth and used pri...

### DIFF
--- a/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
+++ b/src/ServiceStack.Authentication.RavenDb/RavenUserAuthRepository.cs
@@ -209,12 +209,12 @@ namespace ServiceStack.Authentication.RavenDb
 
 		public UserAuth GetUserAuth(string userAuthId)
 		{
-			using (var session = _documentStore.OpenSession())
+			using(_session)
 			{
-                int intAuthId;
-                return int.TryParse(userAuthId, out intAuthId) 
-                    ? session.Load<UserAuth>(intAuthId) 
-                    : session.Load<UserAuth>(userAuthId);
+				int intAuthId;
+				return int.TryParse(userAuthId, out intAuthId)
+					? _session.Load<UserAuth>(intAuthId)
+					: _session.Load<UserAuth>(userAuthId);
 			}
 		}
 


### PR DESCRIPTION
...vately declared _session instance to resolve multiple open session conflicts when calling IDocumentSession::Store.
