### PR TITLE
* Corrected bug in NHibernate mapping for UserOAuthProvider

### DIFF
--- a/src/ServiceStack.Authentication.NHibernate/NHibernateUserAuthRepository.cs
+++ b/src/ServiceStack.Authentication.NHibernate/NHibernateUserAuthRepository.cs
@@ -53,7 +53,7 @@ namespace ServiceStack.Authentication.NHibernate
             if (tokens == null || tokens.Provider.IsNullOrEmpty() || tokens.UserId.IsNullOrEmpty())
                 return null;
 
-            var oAuthProvider = Session.QueryOver<UserOAuthProvider>()
+            var oAuthProvider = Session.QueryOver<UserOAuthProviderPersistenceDto>()
                 .Where(x => x.Provider == tokens.Provider)
                 .And(x => x.UserId == tokens.UserId)
                 .SingleOrDefault();
@@ -141,14 +141,15 @@ namespace ServiceStack.Authentication.NHibernate
         {
             var userAuth = GetUserAuth(authSession, tokens) ?? new UserAuth();
 
-            var oAuthProvider = Session.QueryOver<UserOAuthProvider>()
+            var oAuthProvider = Session.QueryOver<UserOAuthProviderPersistenceDto>()
                 .Where(x => x.Provider == tokens.Provider)
                 .And(x => x.UserId == tokens.UserId)
                 .SingleOrDefault();
 
             if (oAuthProvider == null)
             {
-                oAuthProvider = new UserOAuthProvider {
+                oAuthProvider = new UserOAuthProviderPersistenceDto
+                {
                     Provider = tokens.Provider,
                     UserId = tokens.UserId,
                 };
@@ -177,7 +178,7 @@ namespace ServiceStack.Authentication.NHibernate
         public List<UserOAuthProvider> GetUserOAuthProviders(string userAuthId)
         {
             int authId = int.Parse(userAuthId);
-            var value = Session.QueryOver<UserOAuthProvider>()
+            var value = Session.QueryOver<UserOAuthProviderPersistenceDto>()
                 .Where(x => x.UserAuthId == authId)
                 .OrderBy(x => x.ModifiedDate).Asc
                 .List();

--- a/src/ServiceStack.Authentication.NHibernate/UserOAuthProviderMap.cs
+++ b/src/ServiceStack.Authentication.NHibernate/UserOAuthProviderMap.cs
@@ -1,9 +1,10 @@
-﻿using FluentNHibernate.Mapping;
+﻿using System.Collections.Generic;
+using FluentNHibernate.Mapping;
 using ServiceStack.ServiceInterface.Auth;
 
 namespace ServiceStack.Authentication.NHibernate
 {
-    public class UserOAuthProviderMap : ClassMap<UserOAuthProvider>
+    public class UserOAuthProviderMap : ClassMap<UserOAuthProviderPersistenceDto>
     {
         public UserOAuthProviderMap()
         {
@@ -26,7 +27,7 @@ namespace ServiceStack.Authentication.NHibernate
             Map(x => x.UserId);
             Map(x => x.UserName);
 
-            HasMany(x => x.Items)
+            HasMany(x => x.Items1)
                 .AsMap<string>(
                     index => index.Column("`Key`").Type<string>(),
                     element => element.Column("Value").Type<string>())
@@ -36,6 +37,41 @@ namespace ServiceStack.Authentication.NHibernate
                 .Cascade.All();
 
         }
+
+    }
+
+    public class UserOAuthProviderPersistenceDto : UserOAuthProvider
+    {
+        public UserOAuthProviderPersistenceDto()
+            : base()
+        { }
+
+        public UserOAuthProviderPersistenceDto(UserOAuthProvider userOAuthProvider)
+        {
+            Id = userOAuthProvider.Id;
+            UserAuthId = userOAuthProvider.UserAuthId;
+            Provider = userOAuthProvider.Provider;
+            UserId = userOAuthProvider.UserId;
+            UserName = userOAuthProvider.UserName;
+            DisplayName = userOAuthProvider.DisplayName;
+            FirstName = userOAuthProvider.FirstName;
+            LastName = userOAuthProvider.LastName;
+            Email = userOAuthProvider.Email;
+            RequestToken = userOAuthProvider.RequestToken;
+            RequestTokenSecret = userOAuthProvider.RequestTokenSecret;
+            Items = userOAuthProvider.Items;
+            AccessToken = userOAuthProvider.AccessToken;
+            AccessTokenSecret = userOAuthProvider.AccessTokenSecret;
+            CreatedDate = userOAuthProvider.CreatedDate;
+            ModifiedDate = userOAuthProvider.ModifiedDate;
+        }
+
+        public virtual IDictionary<string, string> Items1
+        {
+            get { return Items; }
+            set { Items = new Dictionary<string, string>(value) ; }
+        }
+    
     }
 
 }


### PR DESCRIPTION
Currently NHibernateUserAuthRepository tries to save and query based on the original UserOAuthProvider. This type contains a Dictionary<,>, which NHibernate can't use because it uses its own implementations (from Iesi.Collections) of generic interface types. I have therefore created UserOAuthProviderPersistenceDto which wraps UserOAuthProvider, and uses IDictionary<,> instead of Dictionary<,>
